### PR TITLE
Support "stripped" A records

### DIFF
--- a/dns-filter.conf
+++ b/dns-filter.conf
@@ -1,7 +1,16 @@
 [dns-filter]
 
 # DNS server to get results from
-master = 192.168.0.1
+upstream_host = 8.8.8.8
+upstream_port = 53
+
+listen_host = 127.0.0.1
+listen_port = 5353
+
+# Stripped 'A' record IP addresses. The program will strip the addresses
+# of the following list from the responses.
+stripped =
+    70.39.191.139
 
 # Invalid 'A' record IP addresses. The program will return "no such
 # domain" if one of these addresses is offered.

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
+# This script is for debug only. For production, please use the init script.
 
 twistd -ny dns-filter.py --uid=$(id -u nobody) --gid=$(id -g nobody) --syslog


### PR DESCRIPTION
This PR adds the support for stripping A records from responses
returned by upstream dns resolver.

Additionally, listening host, listening port and upstream port
are now configurable as well.
