### PR TITLE
Install the new yaml config file instead

### DIFF
--- a/debian/dns-filter.install
+++ b/debian/dns-filter.install
@@ -1,2 +1,2 @@
 dns-filter.py usr/sbin/
-dns-filter.conf etc/
+dns-filter.yml etc/


### PR DESCRIPTION
Last time I changed the config file format to yaml, but forgot to change the filename in `debian/dns-filter.install`. Sorry for that.
